### PR TITLE
Set flash device when setting bank

### DIFF
--- a/SourceLibrary/TBootLdrAtmel91.cpp
+++ b/SourceLibrary/TBootLdrAtmel91.cpp
@@ -724,6 +724,7 @@ UWRESULTCODE TBootLdrAtmel91::SetBank(
         return UWRESULTCODE_UWF_INVALID_FLASH;
     }
     mCurrentBank = nBank;
+    mCurrentDevice = nFlashDevice;
     return UWRESULTCODE_SUCCESS;
 }
 


### PR DESCRIPTION
Calling SetBank() should set the current device handle, otherwise handles can get out of sync.

This pull request is per conversation with Laird's tech support.